### PR TITLE
Remove conversions to and from raw pointers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "readme.md"
 
 [features]
 nightly = []
+int2ptr = []
 
 [dependencies.serde]
 version = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ fn test_match() {
 	}
 }
 
+#[cfg(feature = "int2ptr")]
 #[test]
 fn raw_ptr() {
 	fn c_api(_: *const ()) {}

--- a/src/ptr32.rs
+++ b/src/ptr32.rs
@@ -100,7 +100,7 @@ impl<T: ?Sized> IntPtr32<T> {
 		self.address as usize
 	}
 }
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(feature = "int2ptr", target_pointer_width = "32"))]
 impl<T> IntPtr32<T> {
 	#[inline]
 	pub fn from_ptr(ptr: *const T) -> IntPtr32<T> {

--- a/src/ptr64.rs
+++ b/src/ptr64.rs
@@ -112,7 +112,7 @@ impl<T: ?Sized> IntPtr64<T> {
 		self.address as usize
 	}
 }
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(feature = "int2ptr", target_pointer_width = "64"))]
 impl<T> IntPtr64<T> {
 	#[inline]
 	pub fn from_ptr(ptr: *const T) -> IntPtr64<T> {


### PR DESCRIPTION
There's some discussion going on about pointer provenance with which this code is incompatible.
Keep it available under a feature flag but this code should probably just be removed.