### PR TITLE
Remove int2ptr feature as it is unsound under Strict Provenance rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "readme.md"
 
 [features]
 nightly = []
-int2ptr = []
 
 [dependencies.serde]
 version = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,3 @@ fn test_match() {
 		_ => panic!(),
 	}
 }
-
-#[cfg(feature = "int2ptr")]
-#[test]
-fn raw_ptr() {
-	fn c_api(_: *const ()) {}
-	fn c_mut(_: *mut ()) {}
-
-	let ptr = IntPtr::<i32>::from_usize(0x1000);
-	c_api(ptr.cast().as_ptr());
-	c_mut(ptr.cast().as_mut_ptr());
-}

--- a/src/ptr32.rs
+++ b/src/ptr32.rs
@@ -100,25 +100,6 @@ impl<T: ?Sized> IntPtr32<T> {
 		self.address as usize
 	}
 }
-#[cfg(all(feature = "int2ptr", target_pointer_width = "32"))]
-impl<T> IntPtr32<T> {
-	#[inline]
-	pub fn from_ptr(ptr: *const T) -> IntPtr32<T> {
-		Self::from_raw(ptr as usize as u32)
-	}
-	#[inline]
-	pub fn from_mut_ptr(ptr: *mut T) -> IntPtr32<T> {
-		Self::from_raw(ptr as usize as u32)
-	}
-	#[inline]
-	pub const fn as_ptr(self) -> *const T {
-		self.address as *const T
-	}
-	#[inline]
-	pub const fn as_mut_ptr(self) -> *mut T {
-		self.address as *mut T
-	}
-}
 impl<T> IntPtr32<[T]> {
 	/// Decays the pointee from `[T]` to `T`.
 	#[inline]
@@ -291,4 +272,5 @@ fn units() {
 	assert_eq!(c.into_raw(), 0x1F00);
 	assert_eq!(IntPtr32::<[u32]>::from_raw(0x1000).at(1), IntPtr32::<u32>::from_raw(0x1004));
 	assert_eq!(IntPtr32::<[u32; 2]>::from_raw(0x1000).at(1), IntPtr32::<u32>::from_raw(0x1004));
+	assert_eq!(format!("{}", IntPtr32::<()>::NULL), "0x0");
 }

--- a/src/ptr64.rs
+++ b/src/ptr64.rs
@@ -112,25 +112,6 @@ impl<T: ?Sized> IntPtr64<T> {
 		self.address as usize
 	}
 }
-#[cfg(all(feature = "int2ptr", target_pointer_width = "64"))]
-impl<T> IntPtr64<T> {
-	#[inline]
-	pub fn from_ptr(ptr: *const T) -> IntPtr64<T> {
-		Self::from_raw(ptr as usize as u64)
-	}
-	#[inline]
-	pub fn from_mut_ptr(ptr: *mut T) -> IntPtr64<T> {
-		Self::from_raw(ptr as usize as u64)
-	}
-	#[inline]
-	pub const fn as_ptr(self) -> *const T {
-		self.address as *const T
-	}
-	#[inline]
-	pub const fn as_mut_ptr(self) -> *mut T {
-		self.address as *mut T
-	}
-}
 impl<T> IntPtr64<[T]> {
 	/// Decays the pointee from `[T]` to `T`.
 	#[inline]
@@ -303,4 +284,5 @@ fn units() {
 	assert_eq!(c.into_raw(), 0x1E00);
 	assert_eq!(IntPtr64::<[u32]>::from_raw(0x1000).at(1), IntPtr64::<u32>::from_raw(0x1004));
 	assert_eq!(IntPtr64::<[u32; 2]>::from_raw(0x1000).at(1), IntPtr64::<u32>::from_raw(0x1004));
+	assert_eq!(format!("{}", IntPtr64::<()>::NULL), "0x0");
 }


### PR DESCRIPTION
This code was never published so removing it should have minimal impact.